### PR TITLE
Fix TVMaze country parsing

### DIFF
--- a/src/mediares/maze/parsers.py
+++ b/src/mediares/maze/parsers.py
@@ -25,7 +25,7 @@ def parse_country(
     name = data['name']
     code = data['code']
 
-    by_name = pycountry.countries.get(name=name)
+    by_name = pycountry.countries.lookup(name)
     log.debug(f'name {name!r} parses as: {by_name}')
 
     if strict or by_name is None:

--- a/src/mediares/maze/parsers.py
+++ b/src/mediares/maze/parsers.py
@@ -21,16 +21,23 @@ def parse_country(
     :return: A mapping contain country and timezone data
     """
     timezone = dateutil.tz.gettz(data['timezone'])
+
     name = data['name']
+    code = data['code']
+
     by_name = pycountry.countries.get(name=name)
-    if strict:
-        code = data['code']
+    log.debug(f'name {name!r} parses as: {by_name}')
+
+    if strict or by_name is None:
         by_code = pycountry.countries.get(alpha_2=code)
-        if by_name != by_code:
-            log.debug(f'name {name!r} parses as: {by_name}')
-            log.debug(f'code {code!r} parses as: {by_code}')
-            raise ValueError(f'Ambiguous country')
+        log.debug(f'code {code!r} parses as: {by_code}')
+    else:
+        by_code = None
+
+    if strict and by_name != by_code:
+        raise ValueError(f'Ambiguous country')
+
     return {
-        'country': by_name,
+        'country': by_name or by_code,
         'timezone': timezone,
     }

--- a/src/mediares/maze/parsers.py
+++ b/src/mediares/maze/parsers.py
@@ -10,14 +10,26 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def parse_country(data: typing.Mapping) -> typing.Mapping:
+def parse_country(
+        data: typing.Mapping,
+        strict: bool = False,
+) -> typing.Mapping:
     """Parse a TVMaze country.
 
     :param data: Country data from TVMaze
+    :param strict: Raise ValueError if country is ambiguous
     :return: A mapping contain country and timezone data
     """
     timezone = dateutil.tz.gettz(data['timezone'])
-    by_name = pycountry.countries.get(name=data['name'])
+    name = data['name']
+    by_name = pycountry.countries.get(name=name)
+    if strict:
+        code = data['code']
+        by_code = pycountry.countries.get(alpha_2=code)
+        if by_name != by_code:
+            log.debug(f'name {name!r} parses as: {by_name}')
+            log.debug(f'code {code!r} parses as: {by_code}')
+            raise ValueError(f'Ambiguous country')
     return {
         'country': by_name,
         'timezone': timezone,

--- a/tests/test_parsers/test_country.py
+++ b/tests/test_parsers/test_country.py
@@ -6,7 +6,6 @@ from pytest import mark, param
 from mediares.maze import parsers
 
 
-@mark.parsing
 @mark.parametrize(
     'data', [
         param(
@@ -46,7 +45,6 @@ def test_parse_country(data):
     assert isinstance(parsed['timezone'], datetime.tzinfo)
 
 
-@mark.parsing
 @mark.parametrize(
     'data', [
         param(

--- a/tests/test_parsers/test_country.py
+++ b/tests/test_parsers/test_country.py
@@ -64,7 +64,6 @@ def test_parse_country(data):
                 'timezone': 'Europe/Prague',
             },
             id='official_name',
-            marks=mark.xfail(reason='name is official_name instead of name'),
         ),
         param(
             {

--- a/tests/test_parsers/test_country.py
+++ b/tests/test_parsers/test_country.py
@@ -5,6 +5,7 @@ from pytest import mark, param
 
 from mediares.maze import parsers
 
+
 @mark.parsing
 @mark.parametrize(
     'data', [
@@ -23,7 +24,6 @@ from mediares.maze import parsers
                 'timezone': 'Europe/Prague',
             },
             id='official_name',
-            marks=mark.xfail(reason='name is official_name instead of name'),
         ),
         param(
             {

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
 
 [pytest]
 addopts = -rA -vv --cov --cov-report=term-missing
+xfail_strict=true
 
 [flake8]
 count = True


### PR DESCRIPTION
- Adds a strict option for parsing a TVMaze country.
- Fix parsing of a TVMaze country when name is official_name
- Fix tests silently passing unexpectedly (xpass)
- Remove unnecessary ptest marks